### PR TITLE
fix build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,4 +22,5 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.annotation:annotation:1.4.0'
 }

--- a/app/src/main/java/com/ssaurel/lockdevice/MyAdmin.java
+++ b/app/src/main/java/com/ssaurel/lockdevice/MyAdmin.java
@@ -1,6 +1,6 @@
 package com.ssaurel.lockdevice;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.app.admin.DeviceAdminReceiver;
 import android.content.Context;
 import android.content.Intent;


### PR DESCRIPTION
this fixes

`'android.annotation.NonNull' is not public in 'android.annotation'. Cannot be accessed from outside package`

errors during build.

Verified with:

`$ docker run --tty --interactive --volume=$(pwd):/opt/workspace --workdir=/opt/workspace --rm cangol/android-gradle /bin/sh -c "./gradlew build"` 
